### PR TITLE
Make C3p0 and Hikari "provided" scope

### DIFF
--- a/quartz-core/pom.xml
+++ b/quartz-core/pom.xml
@@ -22,6 +22,7 @@
       <groupId>com.mchange</groupId>
       <artifactId>c3p0</artifactId>
       <version>${c3p0.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Signed-off-by: jhouserizer <jhouse@revolition.net>

In submitting this contribution, I agree to the current Software AG contributor agreement as referred to here: 
https://github.com/quartz-scheduler/contributing/blob/main/CONTRIBUTING.md

This PR...
## Changes
- Make C3p0 and Hikari "provided" scope - see #306

## Checklist
- [X] tested locally
- [X] signed-off on the above mentioned SoftwareAG contributor agreement via `git commit -s` on my commits. 
  (If you're not using command-line, you can use a [browser extension](https://github.com/scottrigby/dco-gh-ui) )

Fixes #306

